### PR TITLE
Small fix to add space in Perk Shop

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -2548,13 +2548,13 @@
   forum:
 - id: 146
   link: https://perk.shop/
-  title: PerkShop
+  title: Perk Shop
   official: false
   new: true
   hide_on_all: false
   desc_short: Give your NFT community exclusive token-gated merch, secret discounts and raffles with your own perk shop
   desc_long:
-  creator: PerkShop
+  creator: Perk Shop
   pricing: free
   # contact:
   categories: app


### PR DESCRIPTION
Adding space in Perk Shop integration name and integrator name.