### PR TITLE
Call to action update on main page (+ gemfile fix to build on windows)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,11 @@ end
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo", "~> 1.2"
-  gem "tzinfo-data"
 end
 
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'tzinfo-data' if Gem.win_platform?
 
 gem "github-pages", "~> 223", :group => :":jekyll-plugins"
+
+gem "webrick", "~> 1.8" if Gem.win_platform?

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ layout: default
           <p class="h4 fw-light mb-4">
             From better distribution to fun with friends, find the resources you need on the POAP Directory!
           </p>
-          <a href="https://documentation.poap.tech/" target="_blank" class="btn btn-primary btn-lg px-4 m-1">Build on POAP</a>
+          <a href="https://documentation.poap.tech/docs/submit-your-app" target="_blank" class="btn btn-primary btn-lg px-4 m-1">Apply to Directory</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updating the CTA on the main page to link to Apply to Directory instead of API Documentation.
Changing the gemfile so it builds on windows and can be commited.

